### PR TITLE
Feature webhooks

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -18,4 +18,7 @@ resources:
   kind: StateRescue
   path: github.com/hammadzf/tf-state-rescuer/api/v1
   version: v1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 version: "3"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ TF State Rescuer is a Kubernetes operator that backs up Kubernetes Secrets conta
 ## Description
 The TF State Rescuer operator is built using [kubebuilder](https://book.kubebuilder.io/). A custom resource called StateRescue is used to specify the name of Terraform state Secret(s) that the corresponding controller should monitor for backup and rescue. This name should match the naming convention that Terraform uses for creating Kubernetes Secrets when the Kubernetes backend is used to store state remotely, which is `tfstate-{workspace}-{secret_suffix}` and the `secret-suffix` is the one which is specified by the Terraform user when configuring the Kubernetes backend. Refer to [Terraform documentation](https://developer.hashicorp.com/terraform/language/backend/kubernetes) for configuring a Kubernetes backend.
 
+### Example manifest for StateRescue resource
 An example YAML manifest for a StateRescue resource is provided below:  
 ```yaml
 apiVersion: terraform.hammadzf.github.io/v1
@@ -20,26 +21,38 @@ spec:
   stateSecretName: "tfstate-default-state"
 ```
 
-Once this StateRescue resource is created, the controller will monitor the corresponding Kubernetes Secret(s) containing state files for the Terraform project that is using the Kubernetes backend. In the above example, the controller looks for Secrets in the 'terraform' namespace as this is the namespace where the StateRescue resource is created. These Secrets are backed up by creating copies in the same namespace, and the LastBackupTime field in StateRescue resource's Status is updated accordingly. The controller looks out for any changes made in the Secret(s) containing Terraform state and updates backup Secrets accordingly in order to keep the latest state. 
+### How does it work?
+Once this StateRescue resource is created, the controller will monitor the corresponding Kubernetes Secret(s) containing state files for the Terraform project that is using the Kubernetes backend. In the above example, the controller looks for Secrets in the 'terraform' namespace as this is the namespace where the StateRescue resource is created. These Secrets are backed up by creating copies in the same namespace, and the `LastBackupTime` field in StateRescue resource's Status is updated accordingly. The controller looks out for any changes made in the Secret(s) containing Terraform state and updates backup Secrets accordingly in order to keep the latest state. 
 
-In case the Secrets being read/updated by Terraform for keeping state are deleted for some reason, the controller rescues Terraform state from the the backup Secrets, and the LastRescueTime field in StateRescue's Status is updated accordingly.
+In case the Secrets being read/updated by Terraform for keeping state are deleted for some reason, the controller rescues Terraform state from the the backup Secrets, and the `LastRescueTime` field in StateRescue's Status is updated accordingly.
+
+### Admission Controller (ValidatingAdmissionWebhook)
+The controller manager for this operator also implements a validation webhook for admission control. It validates incoming (Create and Update) requests to the API server for the StateRescue custom resource. Two kinds of validation are performed, one on the name of the object of StateRescue custom resource and the other regarding its specification. 
+- Name: Name of an object whose kind/resource is defined by a CRD must also be a valid DNS subdomain name ([source](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions)).
+- Spec: The secret name in the StateRescue spec must follow the format `tfstate-{workspace}-{secret_suffix}` to conform with the nomenclature that Terraform uses for naming secrets containing state file data (source[](https://developer.hashicorp.com/terraform/language/backend/kubernetes#configuration-variables)).
+
+The working of the validation webhook can be verified by attempting to create StateRescue objects with invalid name and spec using manifests in [config/samples](./config/samples/).
 
 
 ## Getting Started
 
 ### Prerequisites
 - go version v1.24.0+
-- docker version 17.03+.
-- kubectl version v1.11.3+.
-- Access to a Kubernetes v1.11.3+ cluster.
+- docker version 17.03+
+- kubectl version v1.11.3+
+- Access to a Kubernetes v1.11.3+ cluster
+- cert-manager installed on the Kubernetes cluster (for webhooks)
 
 ### To Deploy on the cluster
+**Install cert-manager**
+You can follow the [cert-manager documentation](https://cert-manager.io/docs/installation/) to install it.
+
 **Build and push your image to the location specified by `IMG`:**
 
 *Option#1: Remote image registry*
 
 ```sh
-make docker-build docker-push IMG=<some-registry>/tf-state-rescuer:tag
+make docker-build docker-push IMG=<some-registry>/<IMAGE_NAME>:<IMAGE_TAG>
 ```
 
 >**NOTE:** This image ought to be published in the personal registry you specified.
@@ -68,7 +81,7 @@ make install
 **Deploy the Manager to the cluster with the image specified by `IMG`:**
 
 ```sh
-make deploy IMG=<some-registry>/tf-state-rescuer:tag
+make deploy IMG=<some-registry>/<IMAGE_NAME>:<IMAGE_TAG>
 ```
 
 > **NOTE**: If you encounter RBAC errors, you may need to grant yourself cluster-admin
@@ -78,7 +91,7 @@ privileges or be logged in as admin.
 You can apply the samples (examples) from the config/sample:
 
 ```sh
-kubectl apply -k config/samples/
+kubectl apply -k config/samples/terraform_v1_staterescue.yaml
 ```
 
 >**NOTE**: Ensure that the samples has default values to test it out.
@@ -87,7 +100,7 @@ kubectl apply -k config/samples/
 **Delete the instances (CRs) from the cluster:**
 
 ```sh
-kubectl delete -k config/samples/
+kubectl delete -k config/samples/terraform_v1_staterescue.yaml
 ```
 
 **Delete the APIs(CRDs) from the cluster:**
@@ -101,6 +114,9 @@ make uninstall
 ```sh
 make undeploy
 ```
+
+**Uninstall the cert-manager**
+You can follow the [cert-manager documentation](https://cert-manager.io/docs/installation/kubectl/#uninstalling) to uninstall it.
 
 ## Project Distribution
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In case the Secrets being read/updated by Terraform for keeping state are delete
 ### Admission Controller (ValidatingAdmissionWebhook)
 The controller manager for this operator also implements a validation webhook for admission control. It validates incoming (Create and Update) requests to the API server for the StateRescue custom resource. Two kinds of validation are performed, one on the name of the object of StateRescue custom resource and the other regarding its specification. 
 - Name: Name of an object whose kind/resource is defined by a CRD must also be a valid DNS subdomain name ([source](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions)).
-- Spec: The secret name in the StateRescue spec must follow the format `tfstate-{workspace}-{secret_suffix}` to conform with the nomenclature that Terraform uses for naming secrets containing state file data (source[](https://developer.hashicorp.com/terraform/language/backend/kubernetes#configuration-variables)).
+- Spec: The secret name in the StateRescue spec must follow the format `tfstate-{workspace}-{secret_suffix}` to conform with the nomenclature that Terraform uses for naming secrets containing state file data ([source](https://developer.hashicorp.com/terraform/language/backend/kubernetes#configuration-variables)).
 
 The working of the validation webhook can be verified by attempting to create StateRescue objects with invalid name and spec using manifests in [config/samples](./config/samples/).
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,7 @@ import (
 
 	terraformv1 "github.com/hammadzf/tf-state-rescuer/api/v1"
 	"github.com/hammadzf/tf-state-rescuer/internal/controller"
+	webhookv1 "github.com/hammadzf/tf-state-rescuer/internal/webhook/v1"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -208,6 +209,13 @@ func main() {
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "StateRescue")
 		os.Exit(1)
+	}
+	// nolint:goconst
+	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+		if err := webhookv1.SetupStateRescueWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "StateRescue")
+			os.Exit(1)
+		}
 	}
 	// +kubebuilder:scaffold:builder
 

--- a/config/certmanager/certificate-metrics.yaml
+++ b/config/certmanager/certificate-metrics.yaml
@@ -1,0 +1,20 @@
+# The following manifests contain a self-signed issuer CR and a metrics certificate CR.
+# More document can be found at https://docs.cert-manager.io
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/name: tf-state-rescuer
+    app.kubernetes.io/managed-by: kustomize
+  name: metrics-certs  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  dnsNames:
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+  # replacements in the config/default/kustomization.yaml file.
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: metrics-server-cert

--- a/config/certmanager/certificate-webhook.yaml
+++ b/config/certmanager/certificate-webhook.yaml
@@ -1,0 +1,20 @@
+# The following manifests contain a self-signed issuer CR and a certificate CR.
+# More document can be found at https://docs.cert-manager.io
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app.kubernetes.io/name: tf-state-rescuer
+    app.kubernetes.io/managed-by: kustomize
+  name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
+  namespace: system
+spec:
+  # SERVICE_NAME and SERVICE_NAMESPACE will be substituted by kustomize
+  # replacements in the config/default/kustomization.yaml file.
+  dnsNames:
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc
+  - SERVICE_NAME.SERVICE_NAMESPACE.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: webhook-server-cert

--- a/config/certmanager/issuer.yaml
+++ b/config/certmanager/issuer.yaml
@@ -1,0 +1,13 @@
+# The following manifest contains a self-signed issuer CR.
+# More information can be found at https://docs.cert-manager.io
+# WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app.kubernetes.io/name: tf-state-rescuer
+    app.kubernetes.io/managed-by: kustomize
+  name: selfsigned-issuer
+  namespace: system
+spec:
+  selfSigned: {}

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- issuer.yaml
+- certificate-webhook.yaml
+- certificate-metrics.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/certmanager/kustomizeconfig.yaml
+++ b/config/certmanager/kustomizeconfig.yaml
@@ -1,0 +1,8 @@
+# This configuration is for teaching kustomize how to update name ref substitution
+nameReference:
+- kind: Issuer
+  group: cert-manager.io
+  fieldSpecs:
+  - kind: Certificate
+    group: cert-manager.io
+    path: spec/issuerRef/name

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -20,9 +20,9 @@ resources:
 - ../manager
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- ../webhook
+- ../webhook
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 # [METRICS] Expose the controller manager metrics service.
@@ -50,13 +50,13 @@ patches:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- path: manager_webhook_patch.yaml
-#  target:
-#    kind: Deployment
+- path: manager_webhook_patch.yaml
+  target:
+    kind: Deployment
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # Uncomment the following replacements to add the cert-manager CA injection annotations
-#replacements:
+replacements:
 # - source: # Uncomment the following block to enable certificates for metrics
 #     kind: Service
 #     version: v1
@@ -117,73 +117,73 @@ patches:
 #         index: 1
 #         create: true
 
-# - source: # Uncomment the following block if you have any webhook
-#     kind: Service
-#     version: v1
-#     name: webhook-service
-#     fieldPath: .metadata.name # Name of the service
-#   targets:
-#     - select:
-#         kind: Certificate
-#         group: cert-manager.io
-#         version: v1
-#         name: serving-cert
-#       fieldPaths:
-#         - .spec.dnsNames.0
-#         - .spec.dnsNames.1
-#       options:
-#         delimiter: '.'
-#         index: 0
-#         create: true
-# - source:
-#     kind: Service
-#     version: v1
-#     name: webhook-service
-#     fieldPath: .metadata.namespace # Namespace of the service
-#   targets:
-#     - select:
-#         kind: Certificate
-#         group: cert-manager.io
-#         version: v1
-#         name: serving-cert
-#       fieldPaths:
-#         - .spec.dnsNames.0
-#         - .spec.dnsNames.1
-#       options:
-#         delimiter: '.'
-#         index: 1
-#         create: true
+ - source: # Uncomment the following block if you have any webhook
+     kind: Service
+     version: v1
+     name: webhook-service
+     fieldPath: .metadata.name # Name of the service
+   targets:
+     - select:
+         kind: Certificate
+         group: cert-manager.io
+         version: v1
+         name: serving-cert
+       fieldPaths:
+         - .spec.dnsNames.0
+         - .spec.dnsNames.1
+       options:
+         delimiter: '.'
+         index: 0
+         create: true
+ - source:
+     kind: Service
+     version: v1
+     name: webhook-service
+     fieldPath: .metadata.namespace # Namespace of the service
+   targets:
+     - select:
+         kind: Certificate
+         group: cert-manager.io
+         version: v1
+         name: serving-cert
+       fieldPaths:
+         - .spec.dnsNames.0
+         - .spec.dnsNames.1
+       options:
+         delimiter: '.'
+         index: 1
+         create: true
 
-# - source: # Uncomment the following block if you have a ValidatingWebhook (--programmatic-validation)
-#     kind: Certificate
-#     group: cert-manager.io
-#     version: v1
-#     name: serving-cert # This name should match the one in certificate.yaml
-#     fieldPath: .metadata.namespace # Namespace of the certificate CR
-#   targets:
-#     - select:
-#         kind: ValidatingWebhookConfiguration
-#       fieldPaths:
-#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#       options:
-#         delimiter: '/'
-#         index: 0
-#         create: true
-# - source:
-#     kind: Certificate
-#     group: cert-manager.io
-#     version: v1
-#     name: serving-cert
-#     fieldPath: .metadata.name
-#   targets:
-#     - select:
-#         kind: ValidatingWebhookConfiguration
-#       fieldPaths:
-#         - .metadata.annotations.[cert-manager.io/inject-ca-from]
-#       options:
-#         delimiter: '/'
-#         index: 1
-#         create: true
+ - source: # Uncomment the following block if you have a ValidatingWebhook (--programmatic-validation)
+     kind: Certificate
+     group: cert-manager.io
+     version: v1
+     name: serving-cert # This name should match the one in certificate.yaml
+     fieldPath: .metadata.namespace # Namespace of the certificate CR
+   targets:
+     - select:
+         kind: ValidatingWebhookConfiguration
+       fieldPaths:
+         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+       options:
+         delimiter: '/'
+         index: 0
+         create: true
+ - source:
+     kind: Certificate
+     group: cert-manager.io
+     version: v1
+     name: serving-cert
+     fieldPath: .metadata.name
+   targets:
+     - select:
+         kind: ValidatingWebhookConfiguration
+       fieldPaths:
+         - .metadata.annotations.[cert-manager.io/inject-ca-from]
+       options:
+         delimiter: '/'
+         index: 1
+         create: true
 
 # - source: # Uncomment the following block if you have a DefaultingWebhook (--defaulting )
 #     kind: Certificate

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -1,0 +1,31 @@
+# This patch ensures the webhook certificates are properly mounted in the manager container.
+# It configures the necessary arguments, volumes, volume mounts, and container ports.
+
+# Add the --webhook-cert-path argument for configuring the webhook certificate path
+- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
+
+# Add the volumeMount for the webhook certificates
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts/-
+  value:
+    mountPath: /tmp/k8s-webhook-server/serving-certs
+    name: webhook-certs
+    readOnly: true
+
+# Add the port configuration for the webhook server
+- op: add
+  path: /spec/template/spec/containers/0/ports/-
+  value:
+    containerPort: 9443
+    name: webhook-server
+    protocol: TCP
+
+# Add the volume configuration for the webhook certificates
+- op: add
+  path: /spec/template/spec/volumes/-
+  value:
+    name: webhook-certs
+    secret:
+      secretName: webhook-server-cert

--- a/config/network-policy/allow-webhook-traffic.yaml
+++ b/config/network-policy/allow-webhook-traffic.yaml
@@ -1,0 +1,27 @@
+# This NetworkPolicy allows ingress traffic to your webhook server running
+# as part of the controller-manager from specific namespaces and pods. CR(s) which uses webhooks
+# will only work when applied in namespaces labeled with 'webhook: enabled'
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  labels:
+    app.kubernetes.io/name: tf-state-rescuer
+    app.kubernetes.io/managed-by: kustomize
+  name: allow-webhook-traffic
+  namespace: system
+spec:
+  podSelector:
+    matchLabels:
+      control-plane: controller-manager
+      app.kubernetes.io/name: tf-state-rescuer
+  policyTypes:
+    - Ingress
+  ingress:
+    # This allows ingress traffic from any namespace with the label webhook: enabled
+    - from:
+      - namespaceSelector:
+          matchLabels:
+            webhook: enabled # Only from namespaces with this label
+      ports:
+        - port: 443
+          protocol: TCP

--- a/config/network-policy/kustomization.yaml
+++ b/config/network-policy/kustomization.yaml
@@ -1,2 +1,3 @@
 resources:
+- allow-webhook-traffic.yaml
 - allow-metrics-traffic.yaml

--- a/config/samples/terraform_v1_staterescue_invalid_name.yaml
+++ b/config/samples/terraform_v1_staterescue_invalid_name.yaml
@@ -1,0 +1,9 @@
+apiVersion: terraform.hammadzf.github.io/v1
+kind: StateRescue
+metadata:
+  labels:
+    app.kubernetes.io/name: tf-state-rescuer
+    app.kubernetes.io/managed-by: kustomize
+  name: =staterescue-invalid-name
+spec:
+  stateSecretName: "terraform-state-default-state"

--- a/config/samples/terraform_v1_staterescue_invalid_spec.yaml
+++ b/config/samples/terraform_v1_staterescue_invalid_spec.yaml
@@ -1,0 +1,9 @@
+apiVersion: terraform.hammadzf.github.io/v1
+kind: StateRescue
+metadata:
+  labels:
+    app.kubernetes.io/name: tf-state-rescuer
+    app.kubernetes.io/managed-by: kustomize
+  name: staterescue-invalid-spec
+spec:
+  stateSecretName: "terraform-state-default-state"

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- manifests.yaml
+- service.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -1,0 +1,22 @@
+# the following config is for teaching kustomize where to look at when substituting nameReference.
+# It requires kustomize v2.1.0 or newer to work properly.
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: MutatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: MutatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-terraform-hammadzf-github-io-v1-staterescue
+  failurePolicy: Fail
+  name: vstaterescue-v1.kb.io
+  rules:
+  - apiGroups:
+    - terraform.hammadzf.github.io
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - staterescues
+  sideEffects: None

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: tf-state-rescuer
+    app.kubernetes.io/managed-by: kustomize
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    control-plane: controller-manager
+    app.kubernetes.io/name: tf-state-rescuer

--- a/internal/controller/staterescue_controller_test.go
+++ b/internal/controller/staterescue_controller_test.go
@@ -39,7 +39,7 @@ var _ = Describe("StateRescue Controller", func() {
 		duration             = time.Second * 10
 		interval             = time.Millisecond * 250
 	)
-	Context("When updating StateResuce status", func() {
+	Context("When updating StateRescue status", func() {
 		It("Should update LastBackupTime and LastRescueTime when TF state secrets are backed up and rescued", func() {
 			By("By creating a new StateRescue resource")
 			ctx := context.Background()

--- a/internal/webhook/v1/staterescue_webhook.go
+++ b/internal/webhook/v1/staterescue_webhook.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	terraformv1 "github.com/hammadzf/tf-state-rescuer/api/v1"
+)
+
+// nolint:unused
+// log is for logging in this package.
+var staterescuelog = logf.Log.WithName("staterescue-resource")
+
+// SetupStateRescueWebhookWithManager registers the webhook for StateRescue in the manager.
+func SetupStateRescueWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).For(&terraformv1.StateRescue{}).
+		WithValidator(&StateRescueCustomValidator{}).
+		Complete()
+}
+
+// TODO(user): EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
+
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
+// NOTE: The 'path' attribute must follow a specific pattern and should not be modified directly here.
+// Modifying the path for an invalid path can cause API server errors; failing to locate the webhook.
+// +kubebuilder:webhook:path=/validate-terraform-hammadzf-github-io-v1-staterescue,mutating=false,failurePolicy=fail,sideEffects=None,groups=terraform.hammadzf.github.io,resources=staterescues,verbs=create;update,versions=v1,name=vstaterescue-v1.kb.io,admissionReviewVersions=v1
+
+// StateRescueCustomValidator struct is responsible for validating the StateRescue resource
+// when it is created, updated, or deleted.
+//
+// NOTE: The +kubebuilder:object:generate=false marker prevents controller-gen from generating DeepCopy methods,
+// as this struct is used only for temporary operations and does not need to be deeply copied.
+type StateRescueCustomValidator struct {
+	// TODO(user): Add more fields as needed for validation
+}
+
+var _ webhook.CustomValidator = &StateRescueCustomValidator{}
+
+// ValidateCreate implements webhook.CustomValidator so a webhook will be registered for the type StateRescue.
+func (v *StateRescueCustomValidator) ValidateCreate(_ context.Context, obj runtime.Object) (admission.Warnings, error) {
+	staterescue, ok := obj.(*terraformv1.StateRescue)
+	if !ok {
+		return nil, fmt.Errorf("expected a StateRescue object but got %T", obj)
+	}
+	staterescuelog.Info("Validation for StateRescue upon creation", "name", staterescue.GetName())
+
+	// TODO(user): fill in your validation logic upon object creation.
+
+	return nil, nil
+}
+
+// ValidateUpdate implements webhook.CustomValidator so a webhook will be registered for the type StateRescue.
+func (v *StateRescueCustomValidator) ValidateUpdate(_ context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	staterescue, ok := newObj.(*terraformv1.StateRescue)
+	if !ok {
+		return nil, fmt.Errorf("expected a StateRescue object for the newObj but got %T", newObj)
+	}
+	staterescuelog.Info("Validation for StateRescue upon update", "name", staterescue.GetName())
+
+	// TODO(user): fill in your validation logic upon object update.
+
+	return nil, nil
+}
+
+// ValidateDelete implements webhook.CustomValidator so a webhook will be registered for the type StateRescue.
+func (v *StateRescueCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	staterescue, ok := obj.(*terraformv1.StateRescue)
+	if !ok {
+		return nil, fmt.Errorf("expected a StateRescue object but got %T", obj)
+	}
+	staterescuelog.Info("Validation for StateRescue upon deletion", "name", staterescue.GetName())
+
+	// TODO(user): fill in your validation logic upon object deletion.
+
+	return nil, nil
+}

--- a/internal/webhook/v1/staterescue_webhook_test.go
+++ b/internal/webhook/v1/staterescue_webhook_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	terraformv1 "github.com/hammadzf/tf-state-rescuer/api/v1"
+	// TODO (user): Add any additional imports if needed
+)
+
+var _ = Describe("StateRescue Webhook", func() {
+	var (
+		obj       *terraformv1.StateRescue
+		oldObj    *terraformv1.StateRescue
+		validator StateRescueCustomValidator
+	)
+
+	BeforeEach(func() {
+		obj = &terraformv1.StateRescue{}
+		oldObj = &terraformv1.StateRescue{}
+		validator = StateRescueCustomValidator{}
+		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
+		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
+		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
+		// TODO (user): Add any setup logic common to all tests
+	})
+
+	AfterEach(func() {
+		// TODO (user): Add any teardown logic common to all tests
+	})
+
+	Context("When creating or updating StateRescue under Validating Webhook", func() {
+		// TODO (user): Add logic for validating webhooks
+		// Example:
+		// It("Should deny creation if a required field is missing", func() {
+		//     By("simulating an invalid creation scenario")
+		//     obj.SomeRequiredField = ""
+		//     Expect(validator.ValidateCreate(ctx, obj)).Error().To(HaveOccurred())
+		// })
+		//
+		// It("Should admit creation if all required fields are present", func() {
+		//     By("simulating an invalid creation scenario")
+		//     obj.SomeRequiredField = "valid_value"
+		//     Expect(validator.ValidateCreate(ctx, obj)).To(BeNil())
+		// })
+		//
+		// It("Should validate updates correctly", func() {
+		//     By("simulating a valid update scenario")
+		//     oldObj.SomeRequiredField = "updated_value"
+		//     obj.SomeRequiredField = "updated_value"
+		//     Expect(validator.ValidateUpdate(ctx, oldObj, obj)).To(BeNil())
+		// })
+	})
+
+})

--- a/internal/webhook/v1/webhook_suite_test.go
+++ b/internal/webhook/v1/webhook_suite_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	terraformv1 "github.com/hammadzf/tf-state-rescuer/api/v1"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	ctx       context.Context
+	cancel    context.CancelFunc
+	k8sClient client.Client
+	cfg       *rest.Config
+	testEnv   *envtest.Environment
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Webhook Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	var err error
+	err = terraformv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:scheme
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
+
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
+		},
+	}
+
+	// Retrieve the first found binary directory to allow running tests from IDEs
+	if getFirstFoundEnvTestBinaryDir() != "" {
+		testEnv.BinaryAssetsDirectory = getFirstFoundEnvTestBinaryDir()
+	}
+
+	// cfg is defined in this file globally.
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	// start webhook server using Manager.
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Host:    webhookInstallOptions.LocalServingHost,
+			Port:    webhookInstallOptions.LocalServingPort,
+			CertDir: webhookInstallOptions.LocalServingCertDir,
+		}),
+		LeaderElection: false,
+		Metrics:        metricsserver.Options{BindAddress: "0"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = SetupStateRescueWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:webhook
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	// wait for the webhook server to get ready.
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+
+		return conn.Close()
+	}).Should(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	cancel()
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})
+
+// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
+// ENVTEST-based tests depend on specific binaries, usually located in paths set by
+// controller-runtime. When running tests directly (e.g., via an IDE) without using
+// Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.
+//
+// This function streamlines the process by finding the required binaries, similar to
+// setting the 'KUBEBUILDER_ASSETS' environment variable. To ensure the binaries are
+// properly set up, run 'make setup-envtest' beforehand.
+func getFirstFoundEnvTestBinaryDir() string {
+	basePath := filepath.Join("..", "..", "..", "bin", "k8s")
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		logf.Log.Error(err, "Failed to read directory", "path", basePath)
+		return ""
+	}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			return filepath.Join(basePath, entry.Name())
+		}
+	}
+	return ""
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -257,6 +257,30 @@ var _ = Describe("Manager", Ordered, func() {
 			))
 		})
 
+		It("should provisioned cert-manager", func() {
+			By("validating that cert-manager has the certificate Secret")
+			verifyCertManager := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "secrets", "webhook-server-cert", "-n", namespace)
+				_, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+			Eventually(verifyCertManager).Should(Succeed())
+		})
+
+		It("should have CA injection for validating webhooks", func() {
+			By("checking CA injection for validating webhooks")
+			verifyCAInjection := func(g Gomega) {
+				cmd := exec.Command("kubectl", "get",
+					"validatingwebhookconfigurations.admissionregistration.k8s.io",
+					"tf-state-rescuer-validating-webhook-configuration",
+					"-o", "go-template={{ range .webhooks }}{{ .clientConfig.caBundle }}{{ end }}")
+				vwhOutput, err := utils.Run(cmd)
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(len(vwhOutput)).To(BeNumerically(">", 10))
+			}
+			Eventually(verifyCAInjection).Should(Succeed())
+		})
+
 		// +kubebuilder:scaffold:e2e-webhooks-checks
 
 		// TODO: Customize the e2e test suite with scenarios specific to your project.


### PR DESCRIPTION
# Overview
This feature implements a validation webhook for admission control. It validates incoming (Create and Update) requests to the controller for the StateRescue custom resource. Two kinds of validation are performed, one on the name of the object of StateRescue custom resource and the other regarding its specification. 

- **Name:** Name of an object whose kind/resource is defined by a CRD must also be a valid DNS subdomain name ([source](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/#customresourcedefinitions)).
- **Spec:** The secret name in the StateRescue spec must follow the format `tfstate-{workspace}-{secret_suffix}` to conform with the nomenclature that Terraform uses for naming secrets containing state file data ([source](https://developer.hashicorp.com/terraform/language/backend/kubernetes#configuration-variables)).

# Summary of changes/additions
- webhook package in internal/webhook
- manifests and configuration files for the webhook its certificates (cert-manager resources)
- tests for the validation webhook
- update in docs 
